### PR TITLE
Add support for publishing to bintray

### DIFF
--- a/SalesforceDesignSystem/build.gradle
+++ b/SalesforceDesignSystem/build.gradle
@@ -1,4 +1,9 @@
 apply plugin: 'com.android.library'
+apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'com.jfrog.bintray'
+
+version = '3.0.0-beta2'
+group = 'com.salesforce.ux'
 
 android {
     compileSdkVersion 24
@@ -7,8 +12,8 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 24
-        versionCode 1
-        versionName "1.0"
+        versionCode 3
+        versionName version
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
@@ -28,4 +33,75 @@ dependencies {
     })
     compile 'com.android.support:appcompat-v7:24.2.1'
     testCompile 'junit:junit:4.12'
+}
+
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+}
+
+task javadoc(type: Javadoc) {
+    source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives javadocJar
+    archives sourcesJar
+}
+
+install {
+    repositories.mavenInstaller {
+        pom {
+            project {
+                name 'SalesforceDesignSystem'
+                url 'https://github.com/salesforce-ux/design-system-android'
+
+                packaging 'aar'
+                version version
+
+                licenses {
+                    license {
+                        name 'BSD 3-clause'
+                        url 'https://github.com/salesforce-ux/design-system-android/blob/master/LICENSE.txt'
+                    }
+                }
+
+                developers {
+                    developer {
+                        name 'Salesforce UX'
+                    }
+                }
+
+                scm {
+                    connection 'https://github.com/salesforce-ux/design-system-android.git'
+                    developerConnection 'https://github.com/salesforce-ux/design-system-android.git'
+                    url 'https://github.com/salesforce-ux/design-system-android'
+                }
+            }
+        }
+    }
+}
+
+bintray {
+    user = System.getenv('BINTRAY_USER')
+    key = System.getenv('BINTRAY_KEY')
+    configurations = ['archives']
+    pkg {
+        repo = 'salesforce-ux'
+        name = 'SalesforceDesignSystem'
+        userOrg = 'salesforce-ux'
+        licenses = ['BSD 3-Clause']
+        vcsUrl = 'https://github.com/salesforce-ux/design-system-android.git'
+        labels = ['android', 'salesforce', 'lightning', 'slds']
+        version {
+            name = version
+            released = new Date()
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,10 +6,15 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
+}
+
+plugins {
+    id "com.jfrog.bintray" version "1.7.3"
 }
 
 allprojects {


### PR DESCRIPTION
I've added most of the configuration necessary to publish a binary aar to bintray so that Android apps can include this library as a gradle dependency.