### PR TITLE
Pass in Resources instead of Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ app:custom_font="SalesforceSans-Regular.ttf"
 ##### Action Icons
 
 ```
-Icons.getDrawable(context,
+Icons.getDrawable(resources,
                   Icons.ActionIcons.ActionNewTask,
                   resources.getDimensionPixelSize(R.dimen.slds_square_icon_medium),
                   resources.getColor(R.color.slds_color_text_link));        
@@ -45,7 +45,7 @@ Icons.getDrawable(context,
 ##### Custom Icons
 
 ```
-Icons.getDrawable(context,
+Icons.getDrawable(resources,
                   Icons.CustomIcons.Custom1,
                   resources.getDimensionPixelSize(R.dimen.slds_square_icon_medium),
                   resources.getColor(R.color.slds_color_text_link));  
@@ -55,7 +55,7 @@ Icons.getDrawable(context,
 ##### Standard Icons
 
 ```
-Icons.getDrawable(context,
+Icons.getDrawable(resources,
                   Icons.StandardIcons.Account,
                   resources.getDimensionPixelSize(R.dimen.slds_square_icon_medium),
                   resources.getColor(R.color.slds_color_text_link));
@@ -67,7 +67,7 @@ Icons.getDrawable(context,
 
 
 ```
-Icons.getDrawable(context,
+Icons.getDrawable(resources,
                   Icons.Utility.AddContact,
                   resources.getDimensionPixelSize(R.dimen.slds_square_icon_medium),
                   resources.getColor(R.color.slds_color_text_link));

--- a/SalesforceDesignSystem/build.gradle
+++ b/SalesforceDesignSystem/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
-version = '3.0.0'
+version = '3.0.1'
 group = 'com.salesforce.ux'
 
 android {

--- a/SalesforceDesignSystem/src/main/java/com/salesforce/designsystem/Icons.java
+++ b/SalesforceDesignSystem/src/main/java/com/salesforce/designsystem/Icons.java
@@ -3,7 +3,7 @@
 
 package com.salesforce.designsystem;
 
-import android.content.Context;
+import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Paint;
@@ -17,98 +17,97 @@ import android.graphics.drawable.Drawable;
 
 public abstract class Icons {
 
-    public static Bitmap getBitmap(Context context, ActionIcons icon, int size) {
-        return getBitmap(context, icon, size, context.getResources().getColor(R.color.slds_color_text_icon_default));
+    public static Bitmap getBitmap(Resources res, ActionIcons icon, int size) {
+        return getBitmap(res, icon, size, res.getColor(R.color.slds_color_text_icon_default));
     }
 
-    public static Drawable getDrawable(Context context, ActionIcons icon, int size) {
-        return new BitmapDrawable(context.getResources(), getBitmap(context, icon, size));
+    public static Drawable getDrawable(Resources res, ActionIcons icon, int size) {
+        return new BitmapDrawable(res, getBitmap(res, icon, size));
     }
 
-    public static Bitmap getBitmap(Context context, ActionIcons icon, int size, int color) {
+    public static Bitmap getBitmap(Resources res, ActionIcons icon, int size, int color) {
         Bitmap bmp = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888);
         Canvas canvas = new Canvas(bmp);
 
-        drawIconGlyph(context, icon.value, size, canvas, color);
+        drawIconGlyph(res, icon.value, size, canvas, color);
 
         return bmp;
     }
 
-    public static Drawable getDrawable(Context context, ActionIcons icon, int size, int color) {
-        return new BitmapDrawable(context.getResources(), getBitmap(context, icon, size, color));
+    public static Drawable getDrawable(Resources res, ActionIcons icon, int size, int color) {
+        return new BitmapDrawable(res, getBitmap(res, icon, size, color));
     }
 
-    public static Bitmap getBitmap(Context context, CustomIcons icon, int size) {
-        return getBitmap(context, icon, size, context.getResources().getColor(R.color.slds_color_text_icon_default));
+    public static Bitmap getBitmap(Resources res, CustomIcons icon, int size) {
+        return getBitmap(res, icon, size, res.getColor(R.color.slds_color_text_icon_default));
     }
 
-    public static Drawable getDrawable(Context context, CustomIcons icon, int size) {
-        return new BitmapDrawable(context.getResources(), getBitmap(context, icon, size));
+    public static Drawable getDrawable(Resources res, CustomIcons icon, int size) {
+        return new BitmapDrawable(res, getBitmap(res, icon, size));
     }
 
-    public static Bitmap getBitmap(Context context, CustomIcons icon, int size, int color) {
+    public static Bitmap getBitmap(Resources res, CustomIcons icon, int size, int color) {
         Bitmap bmp = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888);
         Canvas canvas = new Canvas(bmp);
 
-        drawIconGlyph(context, icon.value, size, canvas, color);
+        drawIconGlyph(res, icon.value, size, canvas, color);
 
         return bmp;
     }
 
-    public static Drawable getDrawable(Context context, CustomIcons icon, int size, int color) {
-        return new BitmapDrawable(context.getResources(), getBitmap(context, icon, size, color));
+    public static Drawable getDrawable(Resources res, CustomIcons icon, int size, int color) {
+        return new BitmapDrawable(res, getBitmap(res, icon, size, color));
     }
 
-    public static Bitmap getBitmap(Context context, StandardIcons icon, int size) {
-        return getBitmap(context, icon, size, context.getResources().getColor(R.color.slds_color_text_icon_default));
+    public static Bitmap getBitmap(Resources res, StandardIcons icon, int size) {
+        return getBitmap(res, icon, size, res.getColor(R.color.slds_color_text_icon_default));
     }
 
-    public static Drawable getDrawable(Context context, StandardIcons icon, int size) {
-        return new BitmapDrawable(context.getResources(), getBitmap(context, icon, size));
+    public static Drawable getDrawable(Resources res, StandardIcons icon, int size) {
+        return new BitmapDrawable(res, getBitmap(res, icon, size));
     }
 
-    public static Bitmap getBitmap(Context context, StandardIcons icon, int size, int color) {
+    public static Bitmap getBitmap(Resources res, StandardIcons icon, int size, int color) {
         Bitmap bmp = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888);
         Canvas canvas = new Canvas(bmp);
 
-        drawIconGlyph(context, icon.value, size, canvas, color);
+        drawIconGlyph(res, icon.value, size, canvas, color);
 
         return bmp;
     }
 
-    public static Drawable getDrawable(Context context, StandardIcons icon, int size, int color) {
-        return new BitmapDrawable(context.getResources(), getBitmap(context, icon, size, color));
+    public static Drawable getDrawable(Resources res, StandardIcons icon, int size, int color) {
+        return new BitmapDrawable(res, getBitmap(res, icon, size, color));
     }
 
-    public static Bitmap getBitmap(Context context, UtilityIcons icon, int size) {
-        return getBitmap(context, icon, size, context.getResources().getColor(R.color.slds_color_text_icon_default));
+    public static Bitmap getBitmap(Resources res, UtilityIcons icon, int size) {
+        return getBitmap(res, icon, size, res.getColor(R.color.slds_color_text_icon_default));
     }
 
-    public static Drawable getDrawable(Context context, UtilityIcons icon, int size) {
-        return new BitmapDrawable(context.getResources(), getBitmap(context, icon, size));
+    public static Drawable getDrawable(Resources res, UtilityIcons icon, int size) {
+        return new BitmapDrawable(res, getBitmap(res, icon, size));
     }
 
-    public static Bitmap getBitmap(Context context, UtilityIcons icon, int size, int color) {
+    public static Bitmap getBitmap(Resources res, UtilityIcons icon, int size, int color) {
         Bitmap bmp = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888);
         Canvas canvas = new Canvas(bmp);
 
-        drawIconGlyph(context, icon.value, size, canvas, color);
+        drawIconGlyph(res, icon.value, size, canvas, color);
 
         return bmp;
     }
 
-    public static Drawable getDrawable(Context context, UtilityIcons icon, int size, int color) {
-        return new BitmapDrawable(context.getResources(), getBitmap(context, icon, size, color));
+    public static Drawable getDrawable(Resources res, UtilityIcons icon, int size, int color) {
+        return new BitmapDrawable(res, getBitmap(res, icon, size, color));
     }
 
-    private static void drawIconGlyph(Context context, String iconChar, int size, Canvas canvas, int color) {
+    private static void drawIconGlyph(Resources res, String iconChar, int size, Canvas canvas, int color) {
         Paint textPaint = new Paint();
         textPaint.setFlags(Paint.ANTI_ALIAS_FLAG);
         textPaint.setTextAlign(Paint.Align.CENTER);
         textPaint.setColor(color);
         textPaint.setTextSize(size);
-        textPaint.setTypeface(Typeface.createFromAsset(
-                context.getResources().getAssets(), "SalesforceDesignSystemIcons.ttf"));
+        textPaint.setTypeface(Typeface.createFromAsset(res.getAssets(), "SalesforceDesignSystemIcons.ttf"));
         float y = (size / 2.0f) - ((textPaint.descent() + textPaint.ascent()) / 2.0f);
         canvas.drawText(iconChar, (size / 2.0f), y, textPaint);
     }

--- a/SampleApp/src/main/java/com/salesforce/designsystem/sample/MainActivity.java
+++ b/SampleApp/src/main/java/com/salesforce/designsystem/sample/MainActivity.java
@@ -1,10 +1,11 @@
 package com.salesforce.designsystem.sample;
 
+import com.salesforce.designsystem.Icons;
+
+import android.content.res.Resources;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.widget.ImageView;
-
-import com.salesforce.designsystem.Icons;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -14,38 +15,64 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
 
         ImageView imageView;
+        Resources res = this.getApplicationContext().getResources();
 
         // Action icons
         imageView = (ImageView) findViewById(R.id.imageAction1);
-        imageView.setImageBitmap(Icons.getBitmap(this.getApplicationContext(), Icons.ActionIcons.ActionAddContact, 100, this.getApplicationContext().getResources().getColor(R.color.slds_color_text_brand)));
+        imageView.setImageBitmap(Icons.getBitmap(res,
+                                                 Icons.ActionIcons.ActionAddContact,
+                                                 100,
+                                                 res.getColor(R.color.slds_color_text_brand)));
 
         imageView = (ImageView) findViewById(R.id.imageAction2);
-        imageView.setImageBitmap(Icons.getBitmap(this.getApplicationContext(), Icons.ActionIcons.ActionJoinGroup, 100));
+        imageView.setImageBitmap(Icons.getBitmap(res,
+                                                 Icons.ActionIcons.ActionJoinGroup,
+                                                 100));
 
         imageView = (ImageView) findViewById(R.id.imageAction3);
-        imageView.setImageBitmap(Icons.getBitmap(this.getApplicationContext(), Icons.ActionIcons.ActionNewAccount, 100));
+        imageView
+                .setImageBitmap(Icons.getBitmap(res,
+                                                Icons.ActionIcons.ActionNewAccount,
+                                                100));
 
         imageView = (ImageView) findViewById(R.id.imageAction4);
-        imageView.setImageBitmap(Icons.getBitmap(this.getApplicationContext(), Icons.ActionIcons.ActionDelete, 100, this.getApplicationContext().getResources().getColor(R.color.slds_color_text_error)));
+        imageView.setImageBitmap(Icons.getBitmap(res,
+                                                 Icons.ActionIcons.ActionDelete,
+                                                 100,
+                                                 res.getColor(R.color.slds_color_text_error)));
 
         imageView = (ImageView) findViewById(R.id.imageAction5);
-        imageView.setImageBitmap(Icons.getBitmap(this.getApplicationContext(), Icons.ActionIcons.ActionNewTask, 100));
+        imageView.setImageBitmap(Icons.getBitmap(res,
+                                                 Icons.ActionIcons.ActionNewTask,
+                                                 100));
 
 
         // Utility icons
         imageView = (ImageView) findViewById(R.id.imageUtility1);
-        imageView.setImageBitmap(Icons.getBitmap(this.getApplicationContext(), Icons.UtilityIcons.UtilityEmoji, 100, this.getApplicationContext().getResources().getColor(R.color.slds_color_text_brand)));
+        imageView.setImageBitmap(Icons.getBitmap(res,
+                                                 Icons.UtilityIcons.UtilityEmoji,
+                                                 100,
+                                                 res.getColor(R.color.slds_color_text_brand)));
 
         imageView = (ImageView) findViewById(R.id.imageUtility2);
-        imageView.setImageBitmap(Icons.getBitmap(this.getApplicationContext(), Icons.UtilityIcons.UtilitySocialshare, 100));
+        imageView.setImageBitmap(Icons.getBitmap(res,
+                                                 Icons.UtilityIcons.UtilitySocialshare,
+                                                 100));
 
         imageView = (ImageView) findViewById(R.id.imageUtility3);
-        imageView.setImageBitmap(Icons.getBitmap(this.getApplicationContext(), Icons.UtilityIcons.UtilityChevrondown, 100));
+        imageView.setImageBitmap(Icons.getBitmap(res,
+                                                 Icons.UtilityIcons.UtilityChevrondown,
+                                                 100));
 
         imageView = (ImageView) findViewById(R.id.imageUtility4);
-        imageView.setImageBitmap(Icons.getBitmap(this.getApplicationContext(), Icons.UtilityIcons.UtilityDownload, 100, this.getApplicationContext().getResources().getColor(R.color.slds_color_text_warning)));
+        imageView.setImageBitmap(Icons.getBitmap(res,
+                                                 Icons.UtilityIcons.UtilityDownload,
+                                                 100,
+                                                 res.getColor(R.color.slds_color_text_warning)));
 
         imageView = (ImageView) findViewById(R.id.imageUtility5);
-        imageView.setImageBitmap(Icons.getBitmap(this.getApplicationContext(), Icons.UtilityIcons.UtilityFeed, 100));
+        imageView.setImageBitmap(Icons.getBitmap(res,
+                                                 Icons.UtilityIcons.UtilityFeed,
+                                                 100));
     }
 }


### PR DESCRIPTION
No need to pass in the Context when all we need is Resources.