### PR TITLE
Remove the application element from the library manifest

### DIFF
--- a/SalesforceDesignSystem/src/main/AndroidManifest.xml
+++ b/SalesforceDesignSystem/src/main/AndroidManifest.xml
@@ -1,9 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.salesforce.designsystem">
-
-    <application android:allowBackup="true" android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
-
-</manifest>
+<manifest package="com.salesforce.designsystem" />

--- a/SalesforceDesignSystem/src/main/res/values/strings.xml
+++ b/SalesforceDesignSystem/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">SalesforceDesignSystem</string>
-</resources>


### PR DESCRIPTION
Closes #11 

This element does not need to exist in a library project, and the attributes can be undesirable, e.g. the `label` attribute can conflict with other libraries when this dependency is added to a consuming project.